### PR TITLE
Enhance duplicate resolver synchronization

### DIFF
--- a/XingManager/Services/XingRepository.cs
+++ b/XingManager/Services/XingRepository.cs
@@ -80,16 +80,26 @@ namespace XingManager.Services
                             continue;
                         }
 
+                        var owner = GetValue(attributes, "OWNER");
+                        var description = GetValue(attributes, "DESCRIPTION");
+                        var location = GetValue(attributes, "LOCATION");
+                        var dwgRef = GetValue(attributes, "DWG_REF");
+                        string lat;
+                        string lng;
+                        TryGetLatLong(br, tr, out lat, out lng);
+
                         var crossingKey = crossing.Trim().ToUpperInvariant();
                         if (!records.TryGetValue(crossingKey, out var record))
                         {
                             record = new CrossingRecord
                             {
                                 Crossing = crossing,
-                                Owner = GetValue(attributes, "OWNER"),
-                                Description = GetValue(attributes, "DESCRIPTION"),
-                                Location = GetValue(attributes, "LOCATION"),
-                                DwgRef = GetValue(attributes, "DWG_REF"),
+                                Owner = owner,
+                                Description = description,
+                                Location = location,
+                                DwgRef = dwgRef,
+                                Lat = lat,
+                                Long = lng,
                                 CanonicalInstance = ObjectId.Null
                             };
 
@@ -100,33 +110,35 @@ namespace XingManager.Services
                         contexts[entId] = new DuplicateResolver.InstanceContext
                         {
                             ObjectId = entId,
-                            SpaceName = spaceName
+                            SpaceName = spaceName,
+                            Owner = owner,
+                            Description = description,
+                            Location = location,
+                            DwgRef = dwgRef,
+                            Lat = lat,
+                            Long = lng
                         };
 
                         if (record.CanonicalInstance.IsNull && string.Equals(spaceName, "Model", StringComparison.OrdinalIgnoreCase))
                         {
                             record.CanonicalInstance = entId;
                             record.Crossing = crossing;
-                            record.Owner = GetValue(attributes, "OWNER");
-                            record.Description = GetValue(attributes, "DESCRIPTION");
-                            record.Location = GetValue(attributes, "LOCATION");
-                            record.DwgRef = GetValue(attributes, "DWG_REF");
-                            string lat, lng;
-                            if (TryGetLatLong(br, tr, out lat, out lng))
-                            {
-                                record.Lat = lat;
-                                record.Long = lng;
-                            }
+                            record.Owner = owner;
+                            record.Description = description;
+                            record.Location = location;
+                            record.DwgRef = dwgRef;
+                            record.Lat = lat;
+                            record.Long = lng;
                         }
                         else if (record.CanonicalInstance.IsNull)
                         {
                             record.CanonicalInstance = entId;
-                            string lat, lng;
-                            if (TryGetLatLong(br, tr, out lat, out lng))
-                            {
-                                record.Lat = lat;
-                                record.Long = lng;
-                            }
+                            record.Owner = owner;
+                            record.Description = description;
+                            record.Location = location;
+                            record.DwgRef = dwgRef;
+                            record.Lat = lat;
+                            record.Long = lng;
                         }
                     }
                 }

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -175,6 +175,7 @@ namespace XingManager
                 gridCrossings.DataSource = _records;
 
                 _duplicateResolver.ResolveDuplicates(_records, _contexts);
+                gridCrossings.Refresh();
                 _isDirty = false;
             }
             catch (Exception ex)
@@ -417,7 +418,13 @@ namespace XingManager
                 _contexts[id] = new DuplicateResolver.InstanceContext
                 {
                     ObjectId = id,
-                    SpaceName = "Model"
+                    SpaceName = "Model",
+                    Owner = record.Owner,
+                    Description = record.Description,
+                    Location = record.Location,
+                    DwgRef = record.DwgRef,
+                    Lat = record.Lat,
+                    Long = record.Long
                 };
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- capture per-instance attribute details during crossing scans so duplicate resolution can display and reuse the data
- extend the duplicate resolver dialog with layout and attribute columns, updating non-canonical instances when a preferred block is chosen
- refresh grid bindings after resolving duplicates and keep new insert contexts in sync with the selected canonical record

## Testing
- `dotnet build XingManager/XingManager.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cc549db6a08322904978d8bf13f9c7