### PR TITLE
Add MATCH TABLE command and UI hook

### DIFF
--- a/XingManager/Services/TableMatcher.cs
+++ b/XingManager/Services/TableMatcher.cs
@@ -1,0 +1,488 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.AutoCAD.ApplicationServices;
+using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.EditorInput;
+using Autodesk.AutoCAD.Runtime;
+using XingManager.Models;
+
+namespace XingManager.Services
+{
+    public class TableMatcher
+    {
+        private static readonly ISet<string> CrossingAttributeTags = new HashSet<string>(new[]
+        {
+            "CROSSING",
+            "XING",
+            "X_NO",
+            "XNUM",
+            "XNUMBER",
+            "NUMBER",
+            "INDEX",
+            "NO",
+            "LABEL"
+        }, StringComparer.OrdinalIgnoreCase);
+
+        private static readonly ISet<string> OwnerAttributeTags = new HashSet<string>(new[]
+        {
+            "OWNER",
+            "OWN",
+            "COMPANY"
+        }, StringComparer.OrdinalIgnoreCase);
+
+        private static readonly ISet<string> DescriptionAttributeTags = new HashSet<string>(new[]
+        {
+            "DESCRIPTION",
+            "DESC"
+        }, StringComparer.OrdinalIgnoreCase);
+
+        private static readonly ISet<string> LocationAttributeTags = new HashSet<string>(new[]
+        {
+            "LOCATION",
+            "LOC"
+        }, StringComparer.OrdinalIgnoreCase);
+
+        private static readonly ISet<string> DwgRefAttributeTags = new HashSet<string>(new[]
+        {
+            "DWG_REF",
+            "DWGREF",
+            "DWGREFNO",
+            "DWGREFNUMBER"
+        }, StringComparer.OrdinalIgnoreCase);
+
+        [CommandMethod("XING_MATCH_TABLE")]
+        public void MatchTable()
+        {
+            var doc = Application.DocumentManager.MdiActiveDocument;
+            if (doc == null)
+            {
+                return;
+            }
+
+            var ed = doc.Editor;
+            try
+            {
+                var options = new PromptEntityOptions("\nSelect a crossing table (Main/Page):")
+                {
+                    AllowNone = false
+                };
+                options.SetRejectMessage("\nEntity must be a table.");
+                options.AddAllowedClass(typeof(Table), true);
+
+                var selection = ed.GetEntity(options);
+                if (selection.Status != PromptStatus.OK)
+                {
+                    Log(ed, "MATCH TABLE cancelled.");
+                    return;
+                }
+
+                using (doc.LockDocument())
+                using (var tr = doc.TransactionManager.StartTransaction())
+                {
+                    var table = tr.GetObject(selection.ObjectId, OpenMode.ForRead) as Table;
+                    if (table == null)
+                    {
+                        Log(ed, "Selected entity is not a table.");
+                        return;
+                    }
+
+                    var tableSync = new TableSync(new TableFactory());
+                    var tableType = tableSync.IdentifyTable(table, tr);
+                    if (tableType == TableSync.XingTableType.Unknown)
+                    {
+                        Log(ed, "Selected table type could not be determined. Command aborted.");
+                        return;
+                    }
+
+                    if (tableType == TableSync.XingTableType.LatLong)
+                    {
+                        Log(ed, "Lat/Long tables are not supported by MATCH TABLE.");
+                        return;
+                    }
+
+                    Log(ed, $"Table type detected: {tableType}.");
+
+                    HashSet<string> duplicateKeys;
+                    var byKey = BuildMapFromTable(table, tableType, out duplicateKeys, message => Log(ed, message));
+                    if (byKey.Count == 0)
+                    {
+                        Log(ed, "Selected table did not provide any crossing rows.");
+                    }
+
+                    var db = doc.Database;
+                    var blockTable = (BlockTable)tr.GetObject(db.BlockTableId, OpenMode.ForRead);
+
+                    var totalXing2 = 0;
+                    var matched = 0;
+                    var updated = 0;
+                    var skippedNoKey = 0;
+                    var skippedNoMatch = 0;
+                    var matchedByDescription = 0;
+                    var errors = 0;
+
+                    foreach (ObjectId btrId in blockTable)
+                    {
+                        var btr = (BlockTableRecord)tr.GetObject(btrId, OpenMode.ForRead);
+                        foreach (ObjectId entId in btr)
+                        {
+                            var br = tr.GetObject(entId, OpenMode.ForRead) as BlockReference;
+                            if (br == null)
+                            {
+                                continue;
+                            }
+
+                            var name = GetEffectiveBlockName(br, tr);
+                            if (!string.Equals(name, "XING2", StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
+
+                            totalXing2++;
+
+                            try
+                            {
+                                ProcessBlock(ed, br, tr, tableType, byKey, ref matched, ref updated, ref skippedNoKey, ref skippedNoMatch, ref matchedByDescription);
+                            }
+                            catch (System.Exception ex)
+                            {
+                                errors++;
+                                Log(ed, $"Block {br.Handle}: {ex.Message}");
+                            }
+                        }
+                    }
+
+                    tr.Commit();
+
+                    if (duplicateKeys.Count > 0)
+                    {
+                        var list = duplicateKeys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+                        Log(ed, $"Duplicate keys ignored: {string.Join(", ", list)}.");
+                    }
+
+                    Log(ed,
+                        $"MATCH TABLE summary -> XING2 blocks: {totalXing2}, matched: {matched}, updated: {updated}, skipped(no key): {skippedNoKey}, skipped(no match): {skippedNoMatch}, matched by description: {matchedByDescription}, errors: {errors}.");
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Log(ed, $"MATCH TABLE failed: {ex.Message}");
+            }
+        }
+
+        private static void ProcessBlock(Editor ed, BlockReference br, Transaction tr, TableSync.XingTableType tableType,
+            IDictionary<string, CrossingRecord> byKey,
+            ref int matched, ref int updated, ref int skippedNoKey, ref int skippedNoMatch, ref int matchedByDescription)
+        {
+            if (br == null)
+            {
+                return;
+            }
+
+            var handle = br.Handle.ToString();
+            var keyValue = GetAttributeText(br, tr, CrossingAttributeTags);
+            var normalizedKey = TableSync.NormalizeKeyForLookup(keyValue);
+            CrossingRecord record = null;
+            var matchedKey = normalizedKey;
+
+            if (!string.IsNullOrEmpty(normalizedKey))
+            {
+                if (!byKey.TryGetValue(normalizedKey, out record))
+                {
+                    skippedNoMatch++;
+                    Log(ed, $"Block {handle}: key '{keyValue}' not found in the selected table.");
+                    return;
+                }
+            }
+            else
+            {
+                if (tableType == TableSync.XingTableType.Page)
+                {
+                    var descriptionValue = GetAttributeText(br, tr, DescriptionAttributeTags);
+                    if (!string.IsNullOrWhiteSpace(descriptionValue))
+                    {
+                        var match = FindByDescription(byKey, descriptionValue);
+                        record = match.Record;
+                        matchedKey = match.Key;
+                        if (record != null)
+                        {
+                            matchedByDescription++;
+                            Log(ed, $"Block {handle}: matched by description '{descriptionValue.Trim()}'.");
+                        }
+                    }
+                }
+
+                if (record == null)
+                {
+                    skippedNoKey++;
+                    Log(ed, $"Block {handle}: missing or invalid crossing key.");
+                    return;
+                }
+            }
+
+            matched++;
+
+            br.UpgradeOpen();
+            var changed = false;
+            changed |= SetAttributeIfExists(br, tr, CrossingAttributeTags, record.Crossing, null);
+            changed |= SetAttributeIfExists(br, tr, OwnerAttributeTags, record.Owner, null);
+            changed |= SetAttributeIfExists(br, tr, DescriptionAttributeTags, record.Description, null);
+
+            if (tableType == TableSync.XingTableType.Main)
+            {
+                changed |= SetAttributeIfExists(br, tr, LocationAttributeTags, record.Location, null);
+                changed |= SetAttributeIfExists(br, tr, DwgRefAttributeTags, record.DwgRef, null);
+            }
+
+            if (changed)
+            {
+                updated++;
+                br.RecordGraphicsModified(true);
+                Log(ed, $"Block {handle}: updated using table key '{matchedKey}'.");
+            }
+            else
+            {
+                Log(ed, $"Block {handle}: already aligned with table key '{matchedKey}'.");
+            }
+        }
+
+        private static string GetEffectiveBlockName(BlockReference br, Transaction tr)
+        {
+            if (br == null)
+            {
+                return string.Empty;
+            }
+
+            var btrId = br.DynamicBlockTableRecord != ObjectId.Null ? br.DynamicBlockTableRecord : br.BlockTableRecord;
+            var btr = (BlockTableRecord)tr.GetObject(btrId, OpenMode.ForRead);
+            return btr?.Name ?? string.Empty;
+        }
+
+        private static bool TryGetAttribute(BlockReference br, Transaction tr, ISet<string> tags, out AttributeReference attribute)
+        {
+            attribute = null;
+            if (br == null || tr == null || tags == null || tags.Count == 0)
+            {
+                return false;
+            }
+
+            var collection = br.AttributeCollection;
+            if (collection == null)
+            {
+                return false;
+            }
+
+            foreach (ObjectId attId in collection)
+            {
+                if (!attId.IsValid)
+                {
+                    continue;
+                }
+
+                var attRef = tr.GetObject(attId, OpenMode.ForRead) as AttributeReference;
+                if (attRef == null)
+                {
+                    continue;
+                }
+
+                var tag = (attRef.Tag ?? string.Empty).Trim();
+                if (tags.Contains(tag))
+                {
+                    attribute = attRef;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetAttributeText(BlockReference br, Transaction tr, ISet<string> tags)
+        {
+            AttributeReference attribute;
+            if (TryGetAttribute(br, tr, tags, out attribute))
+            {
+                return attribute.TextString ?? string.Empty;
+            }
+
+            return string.Empty;
+        }
+
+        private static bool SetAttributeIfExists(BlockReference br, Transaction tr, IEnumerable<string> tags, string value, Action<string> log)
+        {
+            if (br == null || tr == null || tags == null)
+            {
+                return false;
+            }
+
+            var tagSet = new HashSet<string>(tags, StringComparer.OrdinalIgnoreCase);
+            if (tagSet.Count == 0)
+            {
+                return false;
+            }
+
+            var collection = br.AttributeCollection;
+            if (collection == null)
+            {
+                return false;
+            }
+
+            var desired = value ?? string.Empty;
+            var found = false;
+            var updated = false;
+
+            foreach (ObjectId attId in collection)
+            {
+                if (!attId.IsValid)
+                {
+                    continue;
+                }
+
+                var attRef = tr.GetObject(attId, OpenMode.ForRead) as AttributeReference;
+                if (attRef == null)
+                {
+                    continue;
+                }
+
+                var tag = (attRef.Tag ?? string.Empty).Trim();
+                if (!tagSet.Contains(tag))
+                {
+                    continue;
+                }
+
+                found = true;
+                var existing = attRef.TextString ?? string.Empty;
+                if (!string.Equals(existing, desired, StringComparison.Ordinal))
+                {
+                    attRef.UpgradeOpen();
+                    attRef.TextString = desired;
+                    updated = true;
+                }
+            }
+
+            if (!found)
+            {
+                log?.Invoke($"Missing attribute tags ({string.Join(", ", tagSet)}) on block {br.Handle}.");
+            }
+
+            return updated;
+        }
+
+        private static Dictionary<string, CrossingRecord> BuildMapFromTable(Table table, TableSync.XingTableType type)
+        {
+            HashSet<string> duplicateKeys;
+            return BuildMapFromTable(table, type, out duplicateKeys, null);
+        }
+
+        private static Dictionary<string, CrossingRecord> BuildMapFromTable(Table table, TableSync.XingTableType type, out HashSet<string> duplicateKeys, Action<string> log)
+        {
+            var map = new Dictionary<string, CrossingRecord>(StringComparer.OrdinalIgnoreCase);
+            duplicateKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (table == null)
+            {
+                return map;
+            }
+
+            var rowCount = table.Rows.Count;
+            for (var row = 0; row < rowCount; row++)
+            {
+                var rawKey = TableSync.ResolveCrossingKey(table, row, 0);
+                var normalized = TableSync.NormalizeKeyForLookup(rawKey);
+                if (string.IsNullOrEmpty(normalized))
+                {
+                    continue;
+                }
+
+                if (map.ContainsKey(normalized))
+                {
+                    duplicateKeys.Add(normalized);
+                    log?.Invoke($"Row {row}: duplicate key '{normalized}' ignored; keeping the first occurrence.");
+                    continue;
+                }
+
+                var record = new CrossingRecord
+                {
+                    Crossing = (rawKey ?? string.Empty).Trim(),
+                    Owner = ReadCellValue(table, row, 1),
+                    Description = ReadCellValue(table, row, 2)
+                };
+
+                if (type == TableSync.XingTableType.Main)
+                {
+                    record.Location = ReadCellValue(table, row, 3);
+                    record.DwgRef = ReadCellValue(table, row, 4);
+                }
+
+                map[normalized] = record;
+            }
+
+            return map;
+        }
+
+        private static (string Key, CrossingRecord Record) FindByDescription(IDictionary<string, CrossingRecord> byKey, string description)
+        {
+            if (byKey == null || string.IsNullOrWhiteSpace(description))
+            {
+                return (null, null);
+            }
+
+            var trimmed = description.Trim();
+            foreach (var kvp in byKey)
+            {
+                var record = kvp.Value;
+                if (record == null)
+                {
+                    continue;
+                }
+
+                var recordDescription = (record.Description ?? string.Empty).Trim();
+                if (string.Equals(recordDescription, trimmed, StringComparison.OrdinalIgnoreCase))
+                {
+                    return (kvp.Key, record);
+                }
+            }
+
+            return (null, null);
+        }
+
+        private static string ReadCellValue(Table table, int row, int column)
+        {
+            if (table == null || row < 0 || column < 0)
+            {
+                return string.Empty;
+            }
+
+            if (row >= table.Rows.Count || column >= table.Columns.Count)
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                var cell = table.Cells[row, column];
+                var text = cell?.TextString ?? string.Empty;
+                return text.Trim();
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static void Log(Editor ed, string message)
+        {
+            if (ed == null || string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+
+            try
+            {
+                ed.WriteMessage("\n[CrossingManager] " + message);
+            }
+            catch
+            {
+                // Ignore logging failures.
+            }
+        }
+    }
+}

--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -371,7 +371,7 @@ namespace XingManager.Services
             return withoutSpecial.Replace("{", string.Empty).Replace("}", string.Empty);
         }
 
-        private static string ResolveCrossingKey(Table table, int row, int col)
+        internal static string ResolveCrossingKey(Table table, int row, int col)
         {
             if (table == null) return string.Empty;
 
@@ -489,7 +489,7 @@ namespace XingManager.Services
             return candidates.Count == 1 ? candidates[0] : null;
         }
 
-        private static string NormalizeKeyForLookup(string s)
+        internal static string NormalizeKeyForLookup(string s)
         {
             if (string.IsNullOrWhiteSpace(s)) return string.Empty;
 
@@ -528,7 +528,7 @@ namespace XingManager.Services
 
             if (CellHasBlockContent(cell))
             {
-                // We couldn't set an attribute—leave the block intact.
+                // We couldn't set an attribute; leave the block intact.
                 // (Optional: add a log if you want to see which rows failed.)
                 return;
             }

--- a/XingManager/XingForm.Designer.cs
+++ b/XingManager/XingForm.Designer.cs
@@ -12,6 +12,7 @@ namespace XingManager
         private System.Windows.Forms.Button btnRenumber;
         private System.Windows.Forms.Button btnGeneratePage;
         private System.Windows.Forms.Button btnLatLong;
+        private System.Windows.Forms.Button btnMatchTable;
         private System.Windows.Forms.Button btnExport;
         private System.Windows.Forms.Button btnImport;
         private System.Windows.Forms.FlowLayoutPanel buttonPanel;
@@ -36,6 +37,7 @@ namespace XingManager
             this.btnRenumber = new System.Windows.Forms.Button();
             this.btnGeneratePage = new System.Windows.Forms.Button();
             this.btnLatLong = new System.Windows.Forms.Button();
+            this.btnMatchTable = new System.Windows.Forms.Button();
             this.btnExport = new System.Windows.Forms.Button();
             this.btnImport = new System.Windows.Forms.Button();
             this.buttonPanel = new System.Windows.Forms.FlowLayoutPanel();
@@ -138,23 +140,33 @@ namespace XingManager
             this.btnLatLong.Text = "Create LAT/LONG";
             this.btnLatLong.UseVisualStyleBackColor = true;
             this.btnLatLong.Click += new System.EventHandler(this.btnLatLong_Click);
+            //
+            // btnMatchTable
+            //
+            this.btnMatchTable.Location = new System.Drawing.Point(826, 3);
+            this.btnMatchTable.Name = "btnMatchTable";
+            this.btnMatchTable.Size = new System.Drawing.Size(120, 25);
+            this.btnMatchTable.TabIndex = 8;
+            this.btnMatchTable.Text = "MATCH TABLE";
+            this.btnMatchTable.UseVisualStyleBackColor = true;
+            this.btnMatchTable.Click += new System.EventHandler(this.btnMatchTable_Click);
             // 
             // btnExport
             // 
-            this.btnExport.Location = new System.Drawing.Point(826, 3);
+            this.btnExport.Location = new System.Drawing.Point(952, 3);
             this.btnExport.Name = "btnExport";
             this.btnExport.Size = new System.Drawing.Size(75, 25);
-            this.btnExport.TabIndex = 8;
+            this.btnExport.TabIndex = 9;
             this.btnExport.Text = "Export";
             this.btnExport.UseVisualStyleBackColor = true;
             this.btnExport.Click += new System.EventHandler(this.btnExport_Click);
             // 
             // btnImport
             // 
-            this.btnImport.Location = new System.Drawing.Point(907, 3);
+            this.btnImport.Location = new System.Drawing.Point(1033, 3);
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(75, 25);
-            this.btnImport.TabIndex = 9;
+            this.btnImport.TabIndex = 10;
             this.btnImport.Text = "Import";
             this.btnImport.UseVisualStyleBackColor = true;
             this.btnImport.Click += new System.EventHandler(this.btnImport_Click);
@@ -171,6 +183,7 @@ namespace XingManager
             this.buttonPanel.Controls.Add(this.btnRenumber);
             this.buttonPanel.Controls.Add(this.btnGeneratePage);
             this.buttonPanel.Controls.Add(this.btnLatLong);
+            this.buttonPanel.Controls.Add(this.btnMatchTable);
             this.buttonPanel.Controls.Add(this.btnExport);
             this.buttonPanel.Controls.Add(this.btnImport);
             this.buttonPanel.Dock = System.Windows.Forms.DockStyle.Top;

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -79,6 +79,17 @@ namespace XingManager
             CreateOrUpdateLatLongTable();
         }
 
+        public void MatchTableFromCommand()
+        {
+            var doc = Application.DocumentManager.MdiActiveDocument;
+            if (doc == null)
+            {
+                return;
+            }
+
+            doc.SendStringToExecute("XING_MATCH_TABLE ", true, false, true);
+        }
+
         public void RenumberSequentiallyFromCommand()
         {
             RenumberSequential();
@@ -294,6 +305,11 @@ namespace XingManager
         {
             RenumberSequential();
             _isDirty = true;
+        }
+
+        private void btnMatchTable_Click(object sender, EventArgs e)
+        {
+            MatchTableFromCommand();
         }
 
         private void btnGeneratePage_Click(object sender, EventArgs e)

--- a/XingManager/XingManager.csproj
+++ b/XingManager/XingManager.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Services\LayoutUtils.cs" />
     <Compile Include="Services\Serde.cs" />
     <Compile Include="Services\TableFactory.cs" />
+    <Compile Include="Services\TableMatcher.cs" />
     <Compile Include="Services\TableSync.cs" />
     <Compile Include="Services\XingRepository.cs" />
     <Compile Include="XingForm.cs">


### PR DESCRIPTION
## Summary
- add a new TableMatcher service with the XING_MATCH_TABLE command to map table rows to records and update XING2 block attributes with logging and duplicate handling
- expose the existing TableSync key helpers so the matcher can reuse the safe crossing-key reader
- add a MATCH TABLE button and palette hook that runs the new command and include the new service in the project build

## Testing
- `msbuild XingManager.sln` *(fails: command not found in container)*
- `dotnet build XingManager.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaffbfbb48322b10eefa86c3abb7c