### PR TITLE
Fix crossing key extraction and enhance table matching

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -846,12 +846,10 @@ namespace XingManager.Services
                 if (textProp != null)
                 {
                     string text = null;
-                    try { text = textProp.GetValue(item, null) as string; } catch { text = null; }
-                    if (!string.IsNullOrWhiteSpace(text)) { yield return text; continue; }
+                    try { text = textProp.GetValue(item, null) as string; } catch { }
+                    if (!string.IsNullOrWhiteSpace(text))
+                        yield return StripMTextFormatting(text).Trim();
                 }
-
-                var textValue = item.ToString();
-                if (!string.IsNullOrWhiteSpace(textValue)) yield return textValue;
             }
         }
         private static bool CellHasBlockContent(Cell cell)


### PR DESCRIPTION
## Summary
- prevent ResolveCrossingKey from falling back to non-text cell contents
- build composite-to-key indexes and reuse table keys when matching blocks
- avoid blanking CROSSING attributes while still updating owner/description data

## Testing
- `dotnet build XingManager.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc6f497f4832284adbcebf46a0e99