### PR TITLE
Disable auto apply on rescan and key-only table match

### DIFF
--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -28,7 +28,6 @@ namespace XingManager
         private IDictionary<ObjectId, DuplicateResolver.InstanceContext> _contexts = new Dictionary<ObjectId, DuplicateResolver.InstanceContext>();
         private bool _isDirty;
         private bool _isScanning;
-        private bool _skipApplyOnceAfterRescan;
 
         private const string TemplatePath = @"M:\\Drafting\\_CURRENT TEMPLATES\\Compass_Main.dwt";
         private const string TemplateLayoutName = "X";
@@ -57,12 +56,12 @@ namespace XingManager
 
         public void LoadData()
         {
-            RescanRecords();
+            RescanRecords(applyToTables: false);
         }
 
         public void RescanData()
         {
-            RescanRecords();
+            RescanRecords(applyToTables: false);
         }
 
         public void ApplyToDrawing()
@@ -125,7 +124,6 @@ namespace XingManager
                 }
 
                 // Refresh the grid from the DWG **without** writing back to tables
-                _skipApplyOnceAfterRescan = true;
                 RescanRecords(applyToTables: false);
             }
             catch
@@ -185,18 +183,12 @@ namespace XingManager
 
         private void btnRescan_Click(object sender, EventArgs e)
         {
-            RescanRecords();
+            RescanRecords(applyToTables: false);
         }
 
-        // ===== Updated to auto-apply after duplicate resolution =====
+        // ===== Rescan optionally applies after duplicate resolution =====
         private void RescanRecords(bool applyToTables = true)
         {
-            if (_skipApplyOnceAfterRescan)
-            {
-                applyToTables = false;
-                _skipApplyOnceAfterRescan = false;
-            }
-
             _isScanning = true;
             try
             {


### PR DESCRIPTION
## Summary
- prevent Crossing Manager rescan routines from automatically pushing updates to tables, including initial load, manual rescan, and the MATCH TABLE refresh
- restrict MATCH TABLE processing to Column A X# values and update XING2 block attributes from the table row without any composite lookups or table writes

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcbf7d6848322ab40b401a70c7fa6