### PR TITLE
Use table cell probe for block attributes

### DIFF
--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -124,7 +124,7 @@ namespace XingManager
                 }
 
                 // Refresh the grid from the DWG **without** writing back to tables
-                RescanRecords();
+                RescanRecords(applyToTables: false);
             }
             catch
             {
@@ -187,11 +187,12 @@ namespace XingManager
         }
 
         // ===== Rescan refreshes the grid without applying to the drawing =====
-        private void RescanRecords()
+        private void RescanRecords(bool applyToTables = true)
         {
             _isScanning = true;
             try
             {
+                // applyToTables is reserved for symmetry with command workflows; this scan only reads block values.
                 var result = _repository.ScanCrossings();
                 _records = new BindingList<CrossingRecord>(result.Records.ToList());
                 _contexts = result.InstanceContexts ?? new Dictionary<ObjectId, DuplicateResolver.InstanceContext>();


### PR DESCRIPTION
## Summary
- replace the TableCellProbe helper with a reflection-based probe that checks direct and indexed table block attribute lookups and walks block definitions for fallback tags
- enhance TableSync.ResolveCrossingKey to consult the probe before other fallbacks, tighten EnumerateCellContents to only yield true text, and expand attribute getter/setter reflection to iterate all content indices
- expose a no-op applyToTables flag in XingForm.RescanRecords and call it after XING_MATCH_TABLE to refresh the grid without touching tables

## Testing
- `msbuild XingManager.sln` *(fails: command not found in container)*
- `dotnet build XingManager.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d04f12a3e48322a62e8863d786e2b6