### PR TITLE
Update crossing deletion behavior and remove add option

### DIFF
--- a/XingManager/XingForm.Designer.cs
+++ b/XingManager/XingForm.Designer.cs
@@ -6,7 +6,6 @@ namespace XingManager
         private System.Windows.Forms.DataGridView gridCrossings;
         private System.Windows.Forms.Button btnRescan;
         private System.Windows.Forms.Button btnApply;
-        private System.Windows.Forms.Button btnAdd;
         private System.Windows.Forms.Button btnInsert;
         private System.Windows.Forms.Button btnDelete;
         private System.Windows.Forms.Button btnRenumber;
@@ -31,7 +30,6 @@ namespace XingManager
             this.gridCrossings = new System.Windows.Forms.DataGridView();
             this.btnRescan = new System.Windows.Forms.Button();
             this.btnApply = new System.Windows.Forms.Button();
-            this.btnAdd = new System.Windows.Forms.Button();
             this.btnInsert = new System.Windows.Forms.Button();
             this.btnDelete = new System.Windows.Forms.Button();
             this.btnRenumber = new System.Windows.Forms.Button();
@@ -81,92 +79,82 @@ namespace XingManager
             this.btnApply.UseVisualStyleBackColor = true;
             this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
             // 
-            // btnAdd
-            // 
-            this.btnAdd.Location = new System.Drawing.Point(190, 3);
-            this.btnAdd.Name = "btnAdd";
-            this.btnAdd.Size = new System.Drawing.Size(75, 25);
-            this.btnAdd.TabIndex = 2;
-            this.btnAdd.Text = "Add";
-            this.btnAdd.UseVisualStyleBackColor = true;
-            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
-            // 
             // btnInsert
-            // 
-            this.btnInsert.Location = new System.Drawing.Point(271, 3);
+            //
+            this.btnInsert.Location = new System.Drawing.Point(190, 3);
             this.btnInsert.Name = "btnInsert";
             this.btnInsert.Size = new System.Drawing.Size(90, 25);
-            this.btnInsert.TabIndex = 3;
+            this.btnInsert.TabIndex = 2;
             this.btnInsert.Text = "Insert at...";
             this.btnInsert.UseVisualStyleBackColor = true;
             this.btnInsert.Click += new System.EventHandler(this.btnInsert_Click);
-            // 
+            //
             // btnDelete
-            // 
-            this.btnDelete.Location = new System.Drawing.Point(367, 3);
+            //
+            this.btnDelete.Location = new System.Drawing.Point(286, 3);
             this.btnDelete.Name = "btnDelete";
             this.btnDelete.Size = new System.Drawing.Size(110, 25);
-            this.btnDelete.TabIndex = 4;
+            this.btnDelete.TabIndex = 3;
             this.btnDelete.Text = "Delete Selected";
             this.btnDelete.UseVisualStyleBackColor = true;
             this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
-            // 
+            //
             // btnRenumber
-            // 
-            this.btnRenumber.Location = new System.Drawing.Point(483, 3);
+            //
+            this.btnRenumber.Location = new System.Drawing.Point(402, 3);
             this.btnRenumber.Name = "btnRenumber";
             this.btnRenumber.Size = new System.Drawing.Size(85, 25);
-            this.btnRenumber.TabIndex = 5;
+            this.btnRenumber.TabIndex = 4;
             this.btnRenumber.Text = "Renumber";
             this.btnRenumber.UseVisualStyleBackColor = true;
             this.btnRenumber.Click += new System.EventHandler(this.btnRenumber_Click);
-            // 
+            //
             // btnGeneratePage
-            // 
-            this.btnGeneratePage.Location = new System.Drawing.Point(574, 3);
+            //
+            this.btnGeneratePage.Location = new System.Drawing.Point(493, 3);
             this.btnGeneratePage.Name = "btnGeneratePage";
             this.btnGeneratePage.Size = new System.Drawing.Size(120, 25);
-            this.btnGeneratePage.TabIndex = 6;
+            this.btnGeneratePage.TabIndex = 5;
             this.btnGeneratePage.Text = "Generate XING PAGE";
             this.btnGeneratePage.UseVisualStyleBackColor = true;
             this.btnGeneratePage.Click += new System.EventHandler(this.btnGeneratePage_Click);
-            // 
+            //
             // btnLatLong
-            // 
-            this.btnLatLong.Location = new System.Drawing.Point(700, 3);
+            //
+            this.btnLatLong.Location = new System.Drawing.Point(619, 3);
             this.btnLatLong.Name = "btnLatLong";
             this.btnLatLong.Size = new System.Drawing.Size(120, 25);
-            this.btnLatLong.TabIndex = 7;
+            this.btnLatLong.TabIndex = 6;
             this.btnLatLong.Text = "Create LAT/LONG";
             this.btnLatLong.UseVisualStyleBackColor = true;
             this.btnLatLong.Click += new System.EventHandler(this.btnLatLong_Click);
             //
             // btnMatchTable
             //
-            this.btnMatchTable.Location = new System.Drawing.Point(826, 3);
+            this.btnMatchTable.Location = new System.Drawing.Point(745, 3);
             this.btnMatchTable.Name = "btnMatchTable";
             this.btnMatchTable.Size = new System.Drawing.Size(120, 25);
-            this.btnMatchTable.TabIndex = 8;
-            this.btnMatchTable.Text = "MATCH TABLE";
+            this.btnMatchTable.TabIndex = 7;
+            this.btnMatchTable.Text = "Match Table";
             this.btnMatchTable.UseVisualStyleBackColor = true;
             this.btnMatchTable.Click += new System.EventHandler(this.btnMatchTable_Click);
-            // 
+            //
             // btnExport
-            // 
-            this.btnExport.Location = new System.Drawing.Point(952, 3);
+            //
+            this.btnExport.Location = new System.Drawing.Point(871, 3);
             this.btnExport.Name = "btnExport";
             this.btnExport.Size = new System.Drawing.Size(75, 25);
-            this.btnExport.TabIndex = 9;
+            this.btnExport.TabIndex = 8;
             this.btnExport.Text = "Export";
             this.btnExport.UseVisualStyleBackColor = true;
             this.btnExport.Click += new System.EventHandler(this.btnExport_Click);
-            // 
+            //
             // btnImport
-            // 
-            this.btnImport.Location = new System.Drawing.Point(1033, 3);
+            //
+            this.btnImport.Location = new System.Drawing.Point(952, 3);
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(75, 25);
-            this.btnImport.TabIndex = 10;
+            this.btnImport.TabIndex = 9;
             this.btnImport.Text = "Import";
             this.btnImport.UseVisualStyleBackColor = true;
             this.btnImport.Click += new System.EventHandler(this.btnImport_Click);
@@ -177,7 +165,6 @@ namespace XingManager
             this.buttonPanel.AutoScroll = true;
             this.buttonPanel.Controls.Add(this.btnRescan);
             this.buttonPanel.Controls.Add(this.btnApply);
-            this.buttonPanel.Controls.Add(this.btnAdd);
             this.buttonPanel.Controls.Add(this.btnInsert);
             this.buttonPanel.Controls.Add(this.btnDelete);
             this.buttonPanel.Controls.Add(this.btnRenumber);

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -154,14 +154,6 @@ namespace XingManager
 
         private void btnApply_Click(object sender, EventArgs e) => ApplyChangesToDrawing();
 
-        private void btnAdd_Click(object sender, EventArgs e)
-        {
-            var record = new CrossingRecord { Crossing = GenerateNextCrossingName() };
-            _records.Add(record);
-            PromptPlacement(record);
-            _isDirty = true;
-        }
-
         private void btnInsert_Click(object sender, EventArgs e)
         {
             var opts = new PromptIntegerOptions("\nInsert crossing at position:")
@@ -205,9 +197,8 @@ namespace XingManager
             try
             {
                 _repository.DeleteInstances(record.AllInstances);
-                var index = _records.IndexOf(record);
+                _repository.DeleteBlocksByCrossing(record.Crossing);
                 _records.Remove(record);
-                ShiftCrossings(index, -1);
                 _isDirty = true;
             }
             catch (Exception ex)
@@ -890,17 +881,6 @@ namespace XingManager
         {
             if (gridCrossings.CurrentRow == null) return null;
             return gridCrossings.CurrentRow.DataBoundItem as CrossingRecord;
-        }
-
-        private string GenerateNextCrossingName()
-        {
-            var max = 0;
-            foreach (var record in _records)
-            {
-                var token = CrossingRecord.ParseCrossingNumber(record.Crossing);
-                if (token.Number > max) max = token.Number;
-            }
-            return string.Format(CultureInfo.InvariantCulture, "X{0}", max + 1);
         }
 
         private static string GenerateCrossingName(int index)


### PR DESCRIPTION
## Summary
- remove the Add button from the palette and retitle Match Table to use title case
- stop renumbering entries after a delete and ensure related drawing blocks are deleted by attribute

## Testing
- Not Run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d41139f8c48322ac3e02dbd999fc00