### PR TITLE
Add all-page generation workflow for XING layouts

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -140,6 +140,21 @@ namespace XingManager.Services
         // PAGE TABLE CREATION (no extra title row, header bold, height=10)
         // =====================================================================
 
+        // Returns the total width/height of a Page table for a given number of data rows.
+        // Widths: 43.5, 144.5, 393.5; Row height: 25; Header rows: exactly 1.
+        public void GetPageTableSize(int dataRowCount, out double totalWidth, out double totalHeight)
+        {
+            // Keep these in sync with CreateAndInsertPageTable
+            const double W0 = 43.5;
+            const double W1 = 144.5;
+            const double W2 = 393.5;
+            const double RowH = 25.0;
+            const int HeaderRows = 1;
+
+            totalWidth = W0 + W1 + W2;
+            totalHeight = (HeaderRows + Math.Max(0, dataRowCount)) * RowH;
+        }
+
         public void CreateAndInsertPageTable(
             Database db,
             Transaction tr,


### PR DESCRIPTION
## Summary
- add a helper on TableSync to report the page table dimensions for centering calculations
- implement a generate-all-pages workflow with options for including adjacent headings and per-DWG_REF location choices
- prompt for location selection when duplicates exist and center inserted page tables on new layouts

## Testing
- dotnet build XingManager/XingManager.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2c4e54148322900a1b43fb4a54c4