### PR TITLE
Ensure CREATE ALL tables use CG-NOTES layer

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -181,6 +181,12 @@ namespace XingManager.Services
             t.SetDatabaseDefaults();
             t.Position = insertPoint;
 
+            var layerId = LayerUtils.EnsureLayer(db, tr, TableFactory.LayerName);
+            if (!layerId.IsNull)
+            {
+                t.LayerId = layerId;
+            }
+
             var tsDict = (DBDictionary)tr.GetObject(db.TableStyleDictionaryId, OpenMode.ForRead);
             if (tsDict.Contains("Standard"))
                 t.TableStyle = tsDict.GetAt("Standard");


### PR DESCRIPTION
## Summary
- ensure page tables generated through the CREATE ALL workflow are assigned to the CG-NOTES layer

## Testing
- not run (AutoCAD dependencies are unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd2d36d17c8322846f9730c8551ee2