### PR TITLE
Add button to capture lat/long from drawing

### DIFF
--- a/XingManager/XingForm.Designer.cs
+++ b/XingManager/XingForm.Designer.cs
@@ -11,6 +11,7 @@ namespace XingManager
         private System.Windows.Forms.Button btnAddRncPolyline;
         private System.Windows.Forms.Button btnGeneratePage;
         private System.Windows.Forms.Button btnLatLong;
+        private System.Windows.Forms.Button btnAddLatLong;
         private System.Windows.Forms.Button btnMatchTable;
         private System.Windows.Forms.Button btnExport;
         private System.Windows.Forms.Button btnImport;
@@ -35,6 +36,7 @@ namespace XingManager
             this.btnAddRncPolyline = new System.Windows.Forms.Button();
             this.btnGeneratePage = new System.Windows.Forms.Button();
             this.btnLatLong = new System.Windows.Forms.Button();
+            this.btnAddLatLong = new System.Windows.Forms.Button();
             this.btnMatchTable = new System.Windows.Forms.Button();
             this.btnExport = new System.Windows.Forms.Button();
             this.btnImport = new System.Windows.Forms.Button();
@@ -129,32 +131,42 @@ namespace XingManager
             this.btnLatLong.UseVisualStyleBackColor = true;
             this.btnLatLong.Click += new System.EventHandler(this.btnLatLong_Click);
             //
+            // btnAddLatLong
+            //
+            this.btnAddLatLong.Location = new System.Drawing.Point(745, 3);
+            this.btnAddLatLong.Name = "btnAddLatLong";
+            this.btnAddLatLong.Size = new System.Drawing.Size(120, 25);
+            this.btnAddLatLong.TabIndex = 7;
+            this.btnAddLatLong.Text = "Add LAT/LONG";
+            this.btnAddLatLong.UseVisualStyleBackColor = true;
+            this.btnAddLatLong.Click += new System.EventHandler(this.btnAddLatLong_Click);
+            //
             // btnMatchTable
             //
-            this.btnMatchTable.Location = new System.Drawing.Point(745, 3);
+            this.btnMatchTable.Location = new System.Drawing.Point(871, 3);
             this.btnMatchTable.Name = "btnMatchTable";
             this.btnMatchTable.Size = new System.Drawing.Size(120, 25);
-            this.btnMatchTable.TabIndex = 7;
+            this.btnMatchTable.TabIndex = 8;
             this.btnMatchTable.Text = "Match Table";
             this.btnMatchTable.UseVisualStyleBackColor = true;
             this.btnMatchTable.Click += new System.EventHandler(this.btnMatchTable_Click);
             //
             // btnExport
             //
-            this.btnExport.Location = new System.Drawing.Point(967, 3);
+            this.btnExport.Location = new System.Drawing.Point(997, 3);
             this.btnExport.Name = "btnExport";
             this.btnExport.Size = new System.Drawing.Size(75, 25);
-            this.btnExport.TabIndex = 8;
+            this.btnExport.TabIndex = 9;
             this.btnExport.Text = "Export";
             this.btnExport.UseVisualStyleBackColor = true;
             this.btnExport.Click += new System.EventHandler(this.btnExport_Click);
             //
             // btnImport
             //
-            this.btnImport.Location = new System.Drawing.Point(952, 3);
+            this.btnImport.Location = new System.Drawing.Point(1078, 3);
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(75, 25);
-            this.btnImport.TabIndex = 9;
+            this.btnImport.TabIndex = 10;
             this.btnImport.Text = "Import";
             this.btnImport.UseVisualStyleBackColor = true;
             this.btnImport.Click += new System.EventHandler(this.btnImport_Click);
@@ -170,6 +182,7 @@ namespace XingManager
             this.buttonPanel.Controls.Add(this.btnAddRncPolyline);
             this.buttonPanel.Controls.Add(this.btnGeneratePage);
             this.buttonPanel.Controls.Add(this.btnLatLong);
+            this.buttonPanel.Controls.Add(this.btnAddLatLong);
             this.buttonPanel.Controls.Add(this.btnMatchTable);
             this.buttonPanel.Controls.Add(this.btnExport);
             this.buttonPanel.Controls.Add(this.btnImport);


### PR DESCRIPTION
## Summary
- add an **Add LAT/LONG** button to the toolbar next to the existing lat/long tools
- prompt for the UTM zone, switch to model space, and convert a picked point into latitude/longitude for the selected record

## Testing
- not run (AutoCAD environment required)


------
https://chatgpt.com/codex/tasks/task_e_68dd3c3b496483229609247227f1ae0e