### PR TITLE
Add lat/long table auto-generation and styling improvements

### DIFF
--- a/XingManager/Services/TableFactory.cs
+++ b/XingManager/Services/TableFactory.cs
@@ -134,44 +134,6 @@ namespace XingManager.Services
             return table;
         }
 
-        public Table CreateLatLongTable(Database db, Transaction tr, CrossingRecord record)
-        {
-            if (record == null)
-            {
-                throw new ArgumentNullException("record");
-            }
-
-            var table = new Table
-            {
-                TableStyle = EnsureTableStyle(db, tr),
-                LayerId = LayerUtils.EnsureLayer(db, tr, LayerName)
-            };
-
-            table.NumRows = 2;
-            table.NumColumns = 4;
-            table.SetRowHeight(25.0);
-            table.Columns[0].Width = 40.0;
-            table.Columns[1].Width = 150.0;
-            table.Columns[2].Width = 90.0;
-            table.Columns[3].Width = 90.0;
-
-            var textStyleId = db.Textstyle;
-            const double textHeight = 10.0;
-            var headers = new[] { "XING", "DESCRIPTION", "LAT", "LONG" };
-            for (var col = 0; col < headers.Length; col++)
-            {
-                SetCellText(table, 0, col, headers[col], textHeight, textStyleId);
-            }
-
-            SetCellText(table, 1, 0, record.Crossing, textHeight, textStyleId);
-            SetCellText(table, 1, 1, record.Description, textHeight, textStyleId);
-            SetCellText(table, 1, 2, record.Lat, textHeight, textStyleId);
-            SetCellText(table, 1, 3, record.Long, textHeight, textStyleId);
-
-            table.GenerateLayout();
-            return table;
-        }
-
         public void TagTable(Transaction tr, Table table, string tableType)
         {
             if (table == null)

--- a/XingManager/XingForm.Designer.cs
+++ b/XingManager/XingForm.Designer.cs
@@ -10,6 +10,7 @@ namespace XingManager
         private System.Windows.Forms.Button btnRenumber;
         private System.Windows.Forms.Button btnAddRncPolyline;
         private System.Windows.Forms.Button btnGeneratePage;
+        private System.Windows.Forms.Button btnGenerateAllLatLongTables;
         private System.Windows.Forms.Button btnLatLong;
         private System.Windows.Forms.Button btnAddLatLong;
         private System.Windows.Forms.Button btnMatchTable;
@@ -35,6 +36,7 @@ namespace XingManager
             this.btnRenumber = new System.Windows.Forms.Button();
             this.btnAddRncPolyline = new System.Windows.Forms.Button();
             this.btnGeneratePage = new System.Windows.Forms.Button();
+            this.btnGenerateAllLatLongTables = new System.Windows.Forms.Button();
             this.btnLatLong = new System.Windows.Forms.Button();
             this.btnAddLatLong = new System.Windows.Forms.Button();
             this.btnMatchTable = new System.Windows.Forms.Button();
@@ -121,52 +123,62 @@ namespace XingManager
             this.btnGeneratePage.UseVisualStyleBackColor = true;
             this.btnGeneratePage.Click += new System.EventHandler(this.btnGeneratePage_Click);
             //
+            // btnGenerateAllLatLongTables
+            //
+            this.btnGenerateAllLatLongTables.Location = new System.Drawing.Point(619, 3);
+            this.btnGenerateAllLatLongTables.Name = "btnGenerateAllLatLongTables";
+            this.btnGenerateAllLatLongTables.Size = new System.Drawing.Size(160, 25);
+            this.btnGenerateAllLatLongTables.TabIndex = 6;
+            this.btnGenerateAllLatLongTables.Text = "Generate ALL LAT/LONG";
+            this.btnGenerateAllLatLongTables.UseVisualStyleBackColor = true;
+            this.btnGenerateAllLatLongTables.Click += new System.EventHandler(this.btnGenerateAllLatLongTables_Click);
+            //
             // btnLatLong
             //
-            this.btnLatLong.Location = new System.Drawing.Point(619, 3);
+            this.btnLatLong.Location = new System.Drawing.Point(785, 3);
             this.btnLatLong.Name = "btnLatLong";
             this.btnLatLong.Size = new System.Drawing.Size(120, 25);
-            this.btnLatLong.TabIndex = 6;
+            this.btnLatLong.TabIndex = 7;
             this.btnLatLong.Text = "Create LAT/LONG";
             this.btnLatLong.UseVisualStyleBackColor = true;
             this.btnLatLong.Click += new System.EventHandler(this.btnLatLong_Click);
             //
             // btnAddLatLong
             //
-            this.btnAddLatLong.Location = new System.Drawing.Point(745, 3);
+            this.btnAddLatLong.Location = new System.Drawing.Point(911, 3);
             this.btnAddLatLong.Name = "btnAddLatLong";
             this.btnAddLatLong.Size = new System.Drawing.Size(120, 25);
-            this.btnAddLatLong.TabIndex = 7;
+            this.btnAddLatLong.TabIndex = 8;
             this.btnAddLatLong.Text = "Add LAT/LONG";
             this.btnAddLatLong.UseVisualStyleBackColor = true;
             this.btnAddLatLong.Click += new System.EventHandler(this.btnAddLatLong_Click);
             //
             // btnMatchTable
             //
-            this.btnMatchTable.Location = new System.Drawing.Point(871, 3);
+            this.btnMatchTable.Location = new System.Drawing.Point(1037, 3);
             this.btnMatchTable.Name = "btnMatchTable";
             this.btnMatchTable.Size = new System.Drawing.Size(120, 25);
-            this.btnMatchTable.TabIndex = 8;
+            this.btnMatchTable.TabIndex = 9;
             this.btnMatchTable.Text = "Match Table";
             this.btnMatchTable.UseVisualStyleBackColor = true;
             this.btnMatchTable.Click += new System.EventHandler(this.btnMatchTable_Click);
             //
             // btnExport
             //
-            this.btnExport.Location = new System.Drawing.Point(997, 3);
+            this.btnExport.Location = new System.Drawing.Point(1163, 3);
             this.btnExport.Name = "btnExport";
             this.btnExport.Size = new System.Drawing.Size(75, 25);
-            this.btnExport.TabIndex = 9;
+            this.btnExport.TabIndex = 10;
             this.btnExport.Text = "Export";
             this.btnExport.UseVisualStyleBackColor = true;
             this.btnExport.Click += new System.EventHandler(this.btnExport_Click);
             //
             // btnImport
             //
-            this.btnImport.Location = new System.Drawing.Point(1078, 3);
+            this.btnImport.Location = new System.Drawing.Point(1244, 3);
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(75, 25);
-            this.btnImport.TabIndex = 10;
+            this.btnImport.TabIndex = 11;
             this.btnImport.Text = "Import";
             this.btnImport.UseVisualStyleBackColor = true;
             this.btnImport.Click += new System.EventHandler(this.btnImport_Click);
@@ -181,6 +193,7 @@ namespace XingManager
             this.buttonPanel.Controls.Add(this.btnRenumber);
             this.buttonPanel.Controls.Add(this.btnAddRncPolyline);
             this.buttonPanel.Controls.Add(this.btnGeneratePage);
+            this.buttonPanel.Controls.Add(this.btnGenerateAllLatLongTables);
             this.buttonPanel.Controls.Add(this.btnLatLong);
             this.buttonPanel.Controls.Add(this.btnAddLatLong);
             this.buttonPanel.Controls.Add(this.btnMatchTable);


### PR DESCRIPTION
## Summary
- match LAT/LONG table dimensions and header styling with the updated crossing tables and expose sizing helpers
- add a Generate All LAT/LONG Tables workflow/button and reuse it when creating single or multiple XING layouts
- update lat/long table updates and detection to skip headers and recognize the new column names

## Testing
- `dotnet build` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd505c37dc8322a32991e19437a4ab