### PR TITLE
Handle title cell color via reflection

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -380,7 +380,21 @@ namespace XingManager.Services
             titleCell.Alignment = CellAlignment.MiddleCenter;
             titleCell.TextHeight = TitleTextHeight;
             titleCell.TextStyleId = boldStyleId;
-            titleCell.TextColor = titleColor;
+            var textColorProp = titleCell.GetType().GetProperty("TextColor", BindingFlags.Public | BindingFlags.Instance);
+            if (textColorProp != null && textColorProp.CanWrite)
+            {
+                try { textColorProp.SetValue(titleCell, titleColor, null); }
+                catch { }
+            }
+            else
+            {
+                var contentColorProp = titleCell.GetType().GetProperty("ContentColor", BindingFlags.Public | BindingFlags.Instance);
+                if (contentColorProp != null && contentColorProp.CanWrite)
+                {
+                    try { contentColorProp.SetValue(titleCell, titleColor, null); }
+                    catch { }
+                }
+            }
 
             for (int i = 0; i < ordered.Count; i++)
             {


### PR DESCRIPTION
## Summary
- use reflection to set the title cell text color when available
- fall back to ContentColor when TextColor property is missing to preserve compatibility

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd6218c0d483228c67263b1f80419d