### PR TITLE
Improve layout sorting and lat/long import

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -698,6 +698,12 @@ namespace XingManager.Services
             }
             catch { return string.Empty; }
         }
+
+        internal static string ReadCellTextSafe(Table table, int row, int column) => ReadCellText(table, row, column);
+
+        internal static string NormalizeText(string value) => Norm(value);
+
+        internal static int FindLatLongDataStartRow(Table table) => GetDataStartRow(table, 4, IsLatLongHeader);
         // Create (or return) a bold text style. Inherits face/charset from a base style if present.
         // Create (or return) a bold text style. Portable across AutoCAD versions.
         private static ObjectId EnsureBoldTextStyle(Database db, Transaction tr, string styleName, string baseStyleName)


### PR DESCRIPTION
## Summary
- ensure XING page creation processes DWG_REF groups in numeric order so new layouts follow XING numbering
- extend template selection to choose H2O, CNR, or HWY layouts based on owner and description keywords
- scan recognized LAT/LONG tables when loading drawings to populate crossing records with latitude/longitude values

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd6d8437548322b88a4ed0e30d6cb4