### PR TITLE
Cache selected UTM zone during Add Lat/Long workflow

### DIFF
--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -35,6 +35,7 @@ namespace XingManager
         private bool _isDirty;
         private bool _isScanning;
         private bool _isAwaitingRenumber;
+        private int? _currentUtmZone;
 
         private const string TemplatePath = @"M:\Drafting\_CURRENT TEMPLATES\Compass_Main.dwt";
         private const string DefaultTemplateLayoutName = "X";
@@ -2404,10 +2405,15 @@ namespace XingManager
 
             EnsureModelSpaceActive();
 
-            var zone = PromptForUtmZone(editor);
+            var zone = _currentUtmZone ?? PromptForUtmZone(editor);
             if (!zone.HasValue)
             {
                 return;
+            }
+
+            if (!_currentUtmZone.HasValue)
+            {
+                _currentUtmZone = zone;
             }
 
             var point = PromptForPoint(editor, zone.Value);


### PR DESCRIPTION
## Summary
- add a cached UTM zone field on the form to persist the user's selection
- reuse the cached zone during the Add Lat/Long workflow so the user is not repeatedly prompted

## Testing
- `dotnet build XingManager.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7b71b1348322b1561b91e347410a