### PR TITLE
Restrict water crossing coordinate table entries

### DIFF
--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -2321,8 +2321,25 @@ namespace XingManager
 
         private static bool HasLatLongData(CrossingRecord record)
         {
-            if (record == null) return false;
-            return !string.IsNullOrWhiteSpace(record.Lat) || !string.IsNullOrWhiteSpace(record.Long);
+            if (record == null)
+            {
+                return false;
+            }
+
+            var hasCoordinate = !string.IsNullOrWhiteSpace(record.Lat) ||
+                                !string.IsNullOrWhiteSpace(record.Long);
+            if (!hasCoordinate)
+            {
+                return false;
+            }
+
+            var owner = record.Owner?.Trim();
+            if (!string.IsNullOrEmpty(owner) && !string.Equals(owner, "-", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private void CreateOrUpdateLatLongTable()


### PR DESCRIPTION
## Summary
- ensure water crossing coordinate tables only include LAT/LONG records whose owner is blank or '-'
- add explicit owner check while keeping validation for coordinate presence

## Testing
- `dotnet build XingManager.sln` *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7e394f188322b79a4c58039f1423