### PR TITLE
Add zone and DWG context to lat/long workflows

### DIFF
--- a/XingManager/Models/CrossingRecord.cs
+++ b/XingManager/Models/CrossingRecord.cs
@@ -25,6 +25,22 @@ namespace XingManager.Models
 
         public string Long { get; set; }
 
+        public string Zone { get; set; }
+
+        public string ZoneLabel
+        {
+            get
+            {
+                var zone = Zone?.Trim();
+                if (string.IsNullOrEmpty(zone))
+                {
+                    return string.Empty;
+                }
+
+                return string.Format(CultureInfo.InvariantCulture, "ZONE {0}", zone);
+            }
+        }
+
         public List<ObjectId> AllInstances { get; } = new List<ObjectId>();
 
         public ObjectId CanonicalInstance { get; set; }
@@ -48,6 +64,7 @@ namespace XingManager.Models
             DwgRef = other.DwgRef;
             Lat = other.Lat;
             Long = other.Long;
+            Zone = other.Zone;
         }
 
         public override string ToString()

--- a/XingManager/Services/DuplicateResolver.cs
+++ b/XingManager/Services/DuplicateResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;                    // <-- needed for Where/Select/GroupBy
 using System.Windows.Forms;
 using Autodesk.AutoCAD.DatabaseServices;
@@ -25,6 +26,7 @@ namespace XingManager.Services
             public string Description { get; set; }
             public string Location { get; set; }
             public string DwgRef { get; set; }
+            public string Zone { get; set; }
             public string Lat { get; set; }
             public string Long { get; set; }
 
@@ -84,6 +86,7 @@ namespace XingManager.Services
                 record.Description = selected.Description;
                 record.Location = selected.Location;
                 record.DwgRef = selected.DwgRef;
+                record.Zone = selected.Zone;
                 record.Lat = selected.Lat;
                 record.Long = selected.Long;
 
@@ -100,6 +103,7 @@ namespace XingManager.Services
                         ctx.Description = selected.Description;
                         ctx.Location = selected.Location;
                         ctx.DwgRef = selected.DwgRef;
+                        ctx.Zone = selected.Zone;
                         ctx.Lat = selected.Lat;
                         ctx.Long = selected.Long;
                     }
@@ -159,6 +163,7 @@ namespace XingManager.Services
                         Description = ctx.Description ?? string.Empty,
                         Location = ctx.Location ?? string.Empty,
                         DwgRef = ctx.DwgRef ?? string.Empty,
+                        Zone = ctx.Zone ?? string.Empty,
                         Lat = ctx.Lat ?? string.Empty,
                         Long = ctx.Long ?? string.Empty,
                         Canonical = objectId == record.CanonicalInstance
@@ -194,6 +199,7 @@ namespace XingManager.Services
                 Description = string.Empty,
                 Location = string.Empty,
                 DwgRef = string.Empty,
+                Zone = string.Empty,
                 Lat = string.Empty,
                 Long = string.Empty
             };
@@ -209,10 +215,22 @@ namespace XingManager.Services
             public string Description { get; set; }
             public string Location { get; set; }
             public string DwgRef { get; set; }
+            public string Zone { get; set; }
             public string Lat { get; set; }
             public string Long { get; set; }
             public ObjectId ObjectId { get; set; }
             public bool Canonical { get; set; }
+
+            public string ZoneLabel
+            {
+                get
+                {
+                    if (string.IsNullOrWhiteSpace(Zone))
+                        return string.Empty;
+
+                    return string.Format(CultureInfo.InvariantCulture, "ZONE {0}", Zone.Trim());
+                }
+            }
         }
 
         private static bool RequiresResolution(List<DuplicateCandidate> candidates)
@@ -244,6 +262,7 @@ namespace XingManager.Services
                 NormalizeAttribute(candidate.Description),
                 NormalizeAttribute(candidate.Location),
                 NormalizeAttribute(candidate.DwgRef),
+                NormalizeAttribute(candidate.Zone),
                 NormalizeAttribute(candidate.Lat),
                 NormalizeAttribute(candidate.Long));
         }
@@ -336,6 +355,13 @@ namespace XingManager.Services
                     ReadOnly = true,
                     Width = 200
                 };
+                var colZone = new DataGridViewTextBoxColumn
+                {
+                    DataPropertyName = nameof(DuplicateCandidate.ZoneLabel),
+                    HeaderText = "Zone",
+                    ReadOnly = true,
+                    Width = 80
+                };
                 var colDwgRef = new DataGridViewTextBoxColumn
                 {
                     DataPropertyName = nameof(DuplicateCandidate.DwgRef),
@@ -367,7 +393,7 @@ namespace XingManager.Services
 
                 _grid.Columns.AddRange(
                     colCrossing, colLayout, colOwner, colDescription,
-                    colLocation, colDwgRef, colLat, colLong, colCanonical);
+                    colLocation, colZone, colDwgRef, colLat, colLong, colCanonical);
 
                 _grid.CellContentClick += GridOnCellContentClick;
 
@@ -516,9 +542,19 @@ namespace XingManager.Services
                     get { return Representative.Location; }
                 }
 
+                public string Zone
+                {
+                    get { return Representative.Zone; }
+                }
+
                 public string DwgRef
                 {
                     get { return Representative.DwgRef; }
+                }
+
+                public string ZoneLabel
+                {
+                    get { return Representative.ZoneLabel; }
                 }
 
                 public string Lat

--- a/XingManager/Services/Serde.cs
+++ b/XingManager/Services/Serde.cs
@@ -13,7 +13,7 @@ namespace XingManager.Services
     /// </summary>
     public class Serde
     {
-        private static readonly string[] Header = { "CROSSING", "OWNER", "DESCRIPTION", "LOCATION", "DWG_REF", "LAT", "LONG" };
+        private static readonly string[] Header = { "CROSSING", "OWNER", "DESCRIPTION", "LOCATION", "DWG_REF", "LAT", "LONG", "ZONE" };
 
         public void Export(string path, IEnumerable<CrossingRecord> records)
         {
@@ -39,7 +39,8 @@ namespace XingManager.Services
                         Escape(record.Location),
                         Escape(record.DwgRef),
                         Escape(record.Lat),
-                        Escape(record.Long)
+                        Escape(record.Long),
+                        Escape(record.Zone)
                     };
 
                     writer.WriteLine(string.Join(",", values));
@@ -92,7 +93,8 @@ namespace XingManager.Services
                         Location = fields[3],
                         DwgRef = fields[4],
                         Lat = fields[5],
-                        Long = fields[6]
+                        Long = fields[6],
+                        Zone = fields.Count > 7 ? fields[7] : string.Empty
                     };
 
                     var key = record.CrossingKey;

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -141,6 +141,7 @@ namespace XingManager
             gridCrossings.Columns.Add(CreateTextColumn("Owner", "OWNER", 120));
             gridCrossings.Columns.Add(CreateTextColumn("Description", "DESCRIPTION", 200));
             gridCrossings.Columns.Add(CreateTextColumn("Location", "LOCATION", 200));
+            gridCrossings.Columns.Add(CreateTextColumn("Zone", "ZONE", 80));
             gridCrossings.Columns.Add(CreateTextColumn("DwgRef", "DWG_REF", 100));
             gridCrossings.Columns.Add(CreateTextColumn("Lat", "LAT", 100));
             gridCrossings.Columns.Add(CreateTextColumn("Long", "LONG", 100));
@@ -148,6 +149,7 @@ namespace XingManager
             gridCrossings.DataSource = _records;
             gridCrossings.CellValueChanged += GridCrossingsOnCellValueChanged;
             gridCrossings.CurrentCellDirtyStateChanged += GridCrossingsOnCurrentCellDirtyStateChanged;
+            gridCrossings.CellFormatting += GridCrossingsOnCellFormatting;
         }
 
         private static DataGridViewTextBoxColumn CreateTextColumn(string propertyName, string header, int width)
@@ -171,6 +173,25 @@ namespace XingManager
         {
             if (_isScanning) return;
             _isDirty = true;
+        }
+
+        private void GridCrossingsOnCellFormatting(object sender, DataGridViewCellFormattingEventArgs e)
+        {
+            if (e == null || e.ColumnIndex < 0)
+                return;
+
+            var column = gridCrossings.Columns[e.ColumnIndex];
+            if (column == null)
+                return;
+
+            if (!string.Equals(column.DataPropertyName, nameof(CrossingRecord.Zone), StringComparison.Ordinal))
+                return;
+
+            if (e.Value is string zone && !string.IsNullOrWhiteSpace(zone))
+            {
+                e.Value = string.Format(CultureInfo.InvariantCulture, "ZONE {0}", zone.Trim());
+                e.FormattingApplied = true;
+            }
         }
 
         // ===== Buttons (Designer wires to these; keep them) =====
@@ -2447,6 +2468,7 @@ namespace XingManager
 
                 record.Lat = latString;
                 record.Long = longString;
+                record.Zone = zone.Value.ToString(CultureInfo.InvariantCulture);
                 gridCrossings.Refresh();
                 _isDirty = true;
 


### PR DESCRIPTION
## Summary
- add zone tracking to crossing records and expose it in the grid and CSV import/export
- persist zone values in block lat/long metadata and duplicate resolution flows
- expand lat/long table generation and synchronization to include zone labels and DWG reference columns

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd817dac0883228e343dd968fd9c83