### PR TITLE
Remove per-row zone columns and restore water crossing layout

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -160,15 +160,13 @@ namespace XingManager.Services
         {
             const double W0 = 40.0;   // ID
             const double W1 = 200.0;  // Description
-            const double W2 = 70.0;   // Zone
-            const double W3 = 90.0;   // Latitude
-            const double W4 = 90.0;   // Longitude
-            const double W5 = 120.0;  // DWG_REF
+            const double W2 = 90.0;   // Latitude
+            const double W3 = 90.0;   // Longitude
             const double TitleRowHeight = 20.0;
             const double HeaderRowHeight = 25.0;
             const double DataRowHeight = 25.0;
 
-            totalWidth = W0 + W1 + W2 + W3 + W4 + W5;
+            totalWidth = W0 + W1 + W2 + W3;
             totalHeight = TitleRowHeight + HeaderRowHeight + Math.Max(0, dataRowCount) * DataRowHeight;
         }
 
@@ -317,10 +315,8 @@ namespace XingManager.Services
             const double DataRowHeight = 25.0;
             const double W0 = 40.0;   // ID
             const double W1 = 200.0;  // Description
-            const double W2 = 70.0;   // Zone label
-            const double W3 = 90.0;   // Latitude
-            const double W4 = 90.0;   // Longitude
-            const double W5 = 120.0;  // DWG_REF
+            const double W2 = 90.0;   // Latitude
+            const double W3 = 90.0;   // Longitude
 
             var ordered = (records ?? new List<CrossingRecord>())
                 .Where(r => r != null)
@@ -344,16 +340,14 @@ namespace XingManager.Services
             const int titleRow = 0;
             const int headerRow = 1;
             const int dataStart = 2;
-            table.SetSize(dataStart + ordered.Count, 6);
+            table.SetSize(dataStart + ordered.Count, 4);
 
-            if (table.Columns.Count >= 6)
+            if (table.Columns.Count >= 4)
             {
                 table.Columns[0].Width = W0;
                 table.Columns[1].Width = W1;
                 table.Columns[2].Width = W2;
                 table.Columns[3].Width = W3;
-                table.Columns[4].Width = W4;
-                table.Columns[5].Width = W5;
             }
 
             for (int r = 0; r < table.Rows.Count; r++)
@@ -364,10 +358,8 @@ namespace XingManager.Services
 
             table.Cells[headerRow, 0].TextString = "ID";
             table.Cells[headerRow, 1].TextString = "DESCRIPTION";
-            table.Cells[headerRow, 2].TextString = "ZONE";
-            table.Cells[headerRow, 3].TextString = "LATITUDE";
-            table.Cells[headerRow, 4].TextString = "LONGITUDE";
-            table.Cells[headerRow, 5].TextString = "DWG_REF";
+            table.Cells[headerRow, 2].TextString = "LATITUDE";
+            table.Cells[headerRow, 3].TextString = "LONGITUDE";
 
             var boldStyleId = EnsureBoldTextStyle(db, tr, "XING_BOLD", "Standard");
             var headerColor = Color.FromColorIndex(ColorMethod.ByAci, 254);
@@ -418,10 +410,8 @@ namespace XingManager.Services
 
                 table.Cells[row, 0].TextString = NormalizeXKey(rec?.Crossing);
                 table.Cells[row, 1].TextString = rec?.Description ?? string.Empty;
-                table.Cells[row, 2].TextString = rec?.ZoneLabel ?? string.Empty;
-                table.Cells[row, 3].TextString = rec?.Lat ?? string.Empty;
-                table.Cells[row, 4].TextString = rec?.Long ?? string.Empty;
-                table.Cells[row, 5].TextString = rec?.DwgRef ?? string.Empty;
+                table.Cells[row, 2].TextString = rec?.Lat ?? string.Empty;
+                table.Cells[row, 3].TextString = rec?.Long ?? string.Empty;
             }
 
             space.UpgradeOpen();

--- a/XingManager/Services/XingRepository.cs
+++ b/XingManager/Services/XingRepository.cs
@@ -628,7 +628,11 @@ namespace XingManager.Services
                 normalizedHeaders.Add(NormalizeForComparison(TableSync.ReadCellTextSafe(table, 0, column)));
             }
 
-            var updatedHeaders = new[] { "ID", "DESCRIPTION", "ZONE", "LATITUDE", "LONGITUDE", "DWG_REF" };
+            var extendedHeaders = new[] { "ID", "DESCRIPTION", "ZONE", "LATITUDE", "LONGITUDE", "DWG_REF" };
+            if (normalizedHeaders.Count == extendedHeaders.Length && normalizedHeaders.SequenceEqual(extendedHeaders))
+                return true;
+
+            var updatedHeaders = new[] { "ID", "DESCRIPTION", "LATITUDE", "LONGITUDE" };
             if (normalizedHeaders.Count == updatedHeaders.Length && normalizedHeaders.SequenceEqual(updatedHeaders))
                 return true;
 

--- a/XingManager/XingForm.Designer.cs
+++ b/XingManager/XingForm.Designer.cs
@@ -17,6 +17,8 @@ namespace XingManager
         private System.Windows.Forms.Button btnExport;
         private System.Windows.Forms.Button btnImport;
         private System.Windows.Forms.FlowLayoutPanel buttonPanel;
+        private System.Windows.Forms.Label lblUtmZone;
+        private System.Windows.Forms.ComboBox cmbUtmZone;
 
         protected override void Dispose(bool disposing)
         {
@@ -43,6 +45,8 @@ namespace XingManager
             this.btnExport = new System.Windows.Forms.Button();
             this.btnImport = new System.Windows.Forms.Button();
             this.buttonPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.lblUtmZone = new System.Windows.Forms.Label();
+            this.cmbUtmZone = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.gridCrossings)).BeginInit();
             this.buttonPanel.SuspendLayout();
             this.SuspendLayout();
@@ -199,15 +203,42 @@ namespace XingManager
             this.buttonPanel.Controls.Add(this.btnMatchTable);
             this.buttonPanel.Controls.Add(this.btnExport);
             this.buttonPanel.Controls.Add(this.btnImport);
+            this.buttonPanel.Controls.Add(this.lblUtmZone);
+            this.buttonPanel.Controls.Add(this.cmbUtmZone);
             this.buttonPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.buttonPanel.Location = new System.Drawing.Point(0, 0);
             this.buttonPanel.Name = "buttonPanel";
             this.buttonPanel.Size = new System.Drawing.Size(900, 47);
             this.buttonPanel.TabIndex = 1;
             this.buttonPanel.WrapContents = false;
-            // 
+            //
+            // lblUtmZone
+            //
+            this.lblUtmZone.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblUtmZone.AutoSize = true;
+            this.lblUtmZone.Location = new System.Drawing.Point(1325, 13);
+            this.lblUtmZone.Margin = new System.Windows.Forms.Padding(3, 10, 3, 0);
+            this.lblUtmZone.Name = "lblUtmZone";
+            this.lblUtmZone.Size = new System.Drawing.Size(64, 13);
+            this.lblUtmZone.TabIndex = 12;
+            this.lblUtmZone.Text = "UTM Zone:";
+            //
+            // cmbUtmZone
+            //
+            this.cmbUtmZone.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbUtmZone.FormattingEnabled = true;
+            this.cmbUtmZone.Items.AddRange(new object[] {
+            "11",
+            "12"});
+            this.cmbUtmZone.Location = new System.Drawing.Point(1395, 10);
+            this.cmbUtmZone.Margin = new System.Windows.Forms.Padding(3, 7, 3, 3);
+            this.cmbUtmZone.Name = "cmbUtmZone";
+            this.cmbUtmZone.Size = new System.Drawing.Size(60, 21);
+            this.cmbUtmZone.TabIndex = 13;
+            this.cmbUtmZone.SelectedIndexChanged += new System.EventHandler(this.cmbUtmZone_SelectedIndexChanged);
+            //
             // XingForm
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.gridCrossings);


### PR DESCRIPTION
## Summary
- remove the zone column from the grid and add a form-level UTM zone selector
- restore the generated water crossing table to the four-column X/Description/Lat/Long layout while still handling legacy tables

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd63b36248322914afb90ed527dcf