### PR TITLE
Handle lat/long table duplicates during scan

### DIFF
--- a/XingManager/Models/CrossingRecord.cs
+++ b/XingManager/Models/CrossingRecord.cs
@@ -43,6 +43,8 @@ namespace XingManager.Models
 
         public List<ObjectId> AllInstances { get; } = new List<ObjectId>();
 
+        public List<LatLongSource> LatLongSources { get; } = new List<LatLongSource>();
+
         public ObjectId CanonicalInstance { get; set; }
 
         public string CrossingKey
@@ -136,6 +138,25 @@ namespace XingManager.Models
             public int Number { get; private set; }
 
             public string Suffix { get; private set; }
+        }
+
+        public class LatLongSource
+        {
+            public string SourceLabel { get; set; }
+
+            public string Description { get; set; }
+
+            public string Lat { get; set; }
+
+            public string Long { get; set; }
+
+            public string Zone { get; set; }
+
+            public string DwgRef { get; set; }
+
+            public ObjectId TableId { get; set; }
+
+            public int RowIndex { get; set; }
         }
     }
 }


### PR DESCRIPTION
## Summary
- collect lat/long table rows during scans and store them on crossing records for duplicate analysis
- surface lat/long table entries in the duplicate resolver so conflicting coordinates prompt the user to choose a canonical value
- keep canonical block references untouched when a table row supplies the selected lat/long values

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dffa29e6d88322b53fd4bffa65acd9