### PR TITLE
Fix lat/long table row start detection

### DIFF
--- a/XingManager/Services/XingRepository.cs
+++ b/XingManager/Services/XingRepository.cs
@@ -460,7 +460,7 @@ namespace XingManager.Services
             var startRow = TableSync.FindLatLongDataStartRow(table);
             if (startRow <= 0)
             {
-                startRow = 1;
+                startRow = 0;
             }
 
             var columnCount = table.Columns.Count;


### PR DESCRIPTION
## Summary
- ensure lat/long table parsing includes the first row when no header is detected

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0051699988322b9c230126e2e3277