### PR TITLE
Allow panning during duplicate resolution dialogs

### DIFF
--- a/XingManager/Services/DuplicateResolver.cs
+++ b/XingManager/Services/DuplicateResolver.cs
@@ -67,7 +67,7 @@ namespace XingManager.Services
                 // Display the dialog for this group and let the user choose the canonical
                 using (var dialog = new DuplicateResolverDialog(group, displayName, i + 1, duplicateGroups.Count))
                 {
-                    if (dialog.ShowDialog() != DialogResult.OK)
+                    if (ModelessDialogRunner.ShowDialog(dialog) != DialogResult.OK)
                         return false;
                 }
 

--- a/XingManager/Services/LatLongDuplicateResolver.cs
+++ b/XingManager/Services/LatLongDuplicateResolver.cs
@@ -41,7 +41,7 @@ namespace XingManager.Services
 
                 using (var dialog = new LatLongDuplicateResolverDialog(group, displayName, i + 1, groups.Count))
                 {
-                    if (dialog.ShowDialog() != DialogResult.OK)
+                    if (ModelessDialogRunner.ShowDialog(dialog) != DialogResult.OK)
                         return false;
                 }
 
@@ -304,15 +304,7 @@ namespace XingManager.Services
                     DataPropertyName = nameof(DisplayCandidate.SourceType),
                     HeaderText = "Type",
                     ReadOnly = true,
-                    Width = 80
-                };
-
-                var colSource = new DataGridViewTextBoxColumn
-                {
-                    DataPropertyName = nameof(DisplayCandidate.Source),
-                    HeaderText = "Source",
-                    ReadOnly = true,
-                    Width = 220
+                    Width = 120
                 };
 
                 var colDescription = new DataGridViewTextBoxColumn
@@ -320,7 +312,7 @@ namespace XingManager.Services
                     DataPropertyName = nameof(DisplayCandidate.Description),
                     HeaderText = "Description",
                     ReadOnly = true,
-                    Width = 220
+                    Width = 260
                 };
 
                 var colLat = new DataGridViewTextBoxColumn
@@ -346,7 +338,7 @@ namespace XingManager.Services
                     Width = 80
                 };
 
-                _grid.Columns.AddRange(colType, colSource, colDescription, colLat, colLong, colCanonical);
+                _grid.Columns.AddRange(colType, colDescription, colLat, colLong, colCanonical);
                 _grid.CellContentClick += GridOnCellContentClick;
 
                 var headerLabel = new Label

--- a/XingManager/Services/ModelessDialogRunner.cs
+++ b/XingManager/Services/ModelessDialogRunner.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Windows.Forms;
+using AcadApp = Autodesk.AutoCAD.ApplicationServices.Application;
+
+namespace XingManager.Services
+{
+    /// <summary>
+    /// Helper that shows a WinForms dialog modelessly while waiting synchronously
+    /// for the user to close it. This allows interaction with the DWG (panning, zooming, etc.)
+    /// while the dialog is visible.
+    /// </summary>
+    internal static class ModelessDialogRunner
+    {
+        private sealed class WindowHandleWrapper : IWin32Window
+        {
+            private readonly IntPtr _handle;
+
+            public WindowHandleWrapper(IntPtr handle)
+            {
+                _handle = handle;
+            }
+
+            public IntPtr Handle => _handle;
+        }
+
+        public static DialogResult ShowDialog(Form dialog)
+        {
+            if (dialog == null)
+                throw new ArgumentNullException(nameof(dialog));
+
+            var completed = false;
+            var result = DialogResult.None;
+
+            void OnClosed(object sender, FormClosedEventArgs args)
+            {
+                dialog.FormClosed -= OnClosed;
+                completed = true;
+                result = dialog.DialogResult;
+            }
+
+            dialog.FormClosed += OnClosed;
+
+            var mainWindow = AcadApp.MainWindow;
+            if (mainWindow != null)
+            {
+                var owner = new WindowHandleWrapper(mainWindow.Handle);
+                dialog.Show(owner);
+            }
+            else
+            {
+                dialog.Show();
+            }
+
+            while (!completed)
+            {
+                System.Windows.Forms.Application.DoEvents();
+                Thread.Sleep(25);
+            }
+
+            return result;
+        }
+    }
+}

--- a/XingManager/XingManager.csproj
+++ b/XingManager/XingManager.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DuplicateResolver.cs" />
     <Compile Include="Services\LatLongDuplicateResolver.cs" />
+    <Compile Include="Services\ModelessDialogRunner.cs" />
     <Compile Include="Services\LayerUtils.cs" />
     <Compile Include="Services\LayoutUtils.cs" />
     <Compile Include="Services\Serde.cs" />


### PR DESCRIPTION
## Summary
- add a modeless dialog runner so duplicate resolution dialogs no longer block DWG navigation
- update crossing and LAT/LONG duplicate resolvers to use the shared runner
- simplify the LAT/LONG resolver grid by removing the Source column

## Testing
- not run (AutoCAD dependencies are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e00ddc10348322a623415ec9dc9b32