### PR TITLE
Fix lat/long table updates and cancel handling

### DIFF
--- a/XingManager/Services/LatLongDuplicateResolver.cs
+++ b/XingManager/Services/LatLongDuplicateResolver.cs
@@ -366,6 +366,7 @@ namespace XingManager.Services
                 okButton.Click += OkButtonOnClick;
 
                 var cancelButton = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Width = 80 };
+                cancelButton.Click += CancelButtonOnClick;
                 buttonPanel.Controls.Add(okButton);
                 buttonPanel.Controls.Add(cancelButton);
 
@@ -425,6 +426,12 @@ namespace XingManager.Services
                 }
 
                 DialogResult = DialogResult.OK;
+                Close();
+            }
+
+            private void CancelButtonOnClick(object sender, EventArgs e)
+            {
+                DialogResult = DialogResult.Cancel;
                 Close();
             }
 

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -409,8 +409,13 @@ namespace XingManager
 
             try
             {
+                var snapshot = _records.ToList();
+
                 // Persist changes to the crossing blocks/attributes in the DWG
-                _repository.ApplyChanges(_records.ToList(), _tableSync);
+                _repository.ApplyChanges(snapshot, _tableSync);
+
+                // Update any LAT/LONG tables that were discovered during scans
+                _tableSync.UpdateLatLongSourceTables(_doc, snapshot);
 
                 // Also push the changes into any MAIN/PAGE/LATLNG tables
                 UpdateAllXingTablesFromGrid();


### PR DESCRIPTION
## Summary
- add a cancel-button handler so the duplicate LAT/LONG resolver can be dismissed
- push Apply to Drawing changes into previously scanned LAT/LONG tables as well as generated ones
- extend TableSync to update and tag scan-detected LAT/LONG tables using the stored source metadata

## Testing
- `dotnet build XingManager.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e01074568c83228b609a07cb14bcdb