### PR TITLE
Fix LAT/LONG table detection and updates

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -1611,8 +1611,9 @@ namespace XingManager.Services
 
                 if (IsCoordinateValue(latText, -90.0, 90.0) && IsCoordinateValue(longText, -180.0, 180.0))
                 {
-                    var crossing = ReadCellText(table, row, 0);
-                    if (string.IsNullOrWhiteSpace(crossing)) return false;
+                    var crossing = ResolveCrossingKey(table, row, 0);
+                    if (string.IsNullOrWhiteSpace(crossing))
+                        continue;
                     candidates++;
                     continue;
                 }

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -553,7 +553,15 @@ namespace XingManager
 
                         int matched = 0, updated = 0;
 
-                        for (int row = 1; row < table.Rows.Count; row++)
+                        int startRow = 1;
+                        if (kind == TableSync.XingTableType.LatLong)
+                        {
+                            try { startRow = TableSync.FindLatLongDataStartRow(table); }
+                            catch { startRow = 1; }
+                            if (startRow <= 0) startRow = 1;
+                        }
+
+                        for (int row = startRow; row < table.Rows.Count; row++)
                         {
                             string xRaw = ReadXFromCellAttributeOnly(table, row, tr);
                             if (string.IsNullOrWhiteSpace(xRaw))
@@ -1010,7 +1018,15 @@ namespace XingManager
 
                         table.UpgradeOpen();
 
-                        for (int row = 1; row < table.Rows.Count; row++)
+                        int startRow = 1;
+                        if (kind == TableSync.XingTableType.LatLong)
+                        {
+                            try { startRow = TableSync.FindLatLongDataStartRow(table); }
+                            catch { startRow = 1; }
+                            if (startRow <= 0) startRow = 1;
+                        }
+
+                        for (int row = startRow; row < table.Rows.Count; row++)
                         {
                             // Column A: attribute-first key; fall back to plain text token.
                             string xRaw = ReadXFromCellAttributeOnly(table, row, tr);


### PR DESCRIPTION
## Summary
- allow LAT/LONG table detection to read bubble values from attributes and keep scanning when empty
- use the computed LAT/LONG data start row when syncing grid data back to tables
- apply the same start-row handling when deleting rows so headerless tables can remove their first entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e019a8b13c8322bc54177dc7c733ee