### PR TITLE
Propagate LAT/LONG duplicate resolutions to table sources

### DIFF
--- a/XingManager/Services/LatLongDuplicateResolver.cs
+++ b/XingManager/Services/LatLongDuplicateResolver.cs
@@ -57,6 +57,18 @@ namespace XingManager.Services
                 if (!string.IsNullOrWhiteSpace(selected.DwgRef))
                     record.DwgRef = selected.DwgRef;
 
+                if (record.LatLongSources != null && record.LatLongSources.Count > 0)
+                {
+                    foreach (var source in record.LatLongSources)
+                    {
+                        source.Lat = selected.Lat;
+                        source.Long = selected.Long;
+                        source.Zone = selected.Zone;
+                        if (!string.IsNullOrWhiteSpace(selected.DwgRef))
+                            source.DwgRef = selected.DwgRef;
+                    }
+                }
+
                 foreach (var instanceId in record.AllInstances)
                 {
                     if (contexts != null && contexts.TryGetValue(instanceId, out var ctx) && ctx != null)


### PR DESCRIPTION
## Summary
- propagate the chosen canonical LAT/LONG values to all table sources for the affected crossing
- keep LAT/LONG table rows in sync with the resolved record values to avoid repeated duplicate prompts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01f84c2288322bf8b2f92ed6e2804