### PR TITLE
Update LAT/LONG tables after resolving duplicates

### DIFF
--- a/XingManager/Services/LatLongDuplicateResolver.cs
+++ b/XingManager/Services/LatLongDuplicateResolver.cs
@@ -57,6 +57,18 @@ namespace XingManager.Services
                 if (!string.IsNullOrWhiteSpace(selected.DwgRef))
                     record.DwgRef = selected.DwgRef;
 
+                if (record.LatLongSources != null && record.LatLongSources.Count > 0)
+                {
+                    foreach (var source in record.LatLongSources)
+                    {
+                        source.Lat = selected.Lat;
+                        source.Long = selected.Long;
+                        source.Zone = selected.Zone;
+                        if (!string.IsNullOrWhiteSpace(selected.DwgRef))
+                            source.DwgRef = selected.DwgRef;
+                    }
+                }
+
                 foreach (var instanceId in record.AllInstances)
                 {
                     if (contexts != null && contexts.TryGetValue(instanceId, out var ctx) && ctx != null)

--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -180,28 +180,34 @@ namespace XingManager.Services
                         continue;
 
                     var identifiedType = IdentifyTable(table, tr);
-                    if (identifiedType == XingTableType.LatLong)
-                    {
-                        // Already handled by the regular update path.
-                        continue;
-                    }
-
                     try
                     {
                         var rowIndexMap = BuildLatLongRowIndexMap(table.ObjectId, byKey?.Values);
                         UpdateLatLongTable(table, byKey, out var matched, out var updated, rowIndexMap);
-                        _factory.TagTable(tr, table, XingTableType.LatLong.ToString().ToUpperInvariant());
+
+                        var typeLabel = XingTableType.LatLong.ToString().ToUpperInvariant();
+                        _factory.TagTable(tr, table, typeLabel);
+
+                        var suffix = identifiedType == XingTableType.LatLong
+                            ? string.Empty
+                            : " (source-scan)";
+
                         Log(string.Format(
                             CultureInfo.InvariantCulture,
-                            "Table {0}: LATLONG (source-scan) matched={1} updated={2}",
-                            table.ObjectId.Handle, matched, updated));
+                            "Table {0}: {1}{2} matched={3} updated={4}",
+                            table.ObjectId.Handle,
+                            typeLabel,
+                            suffix,
+                            matched,
+                            updated));
                     }
                     catch (Exception ex)
                     {
                         Log(string.Format(
                             CultureInfo.InvariantCulture,
                             "Failed to update LAT/LONG table {0}: {1}",
-                            table.ObjectId.Handle, ex.Message));
+                            table.ObjectId.Handle,
+                            ex.Message));
                     }
                 }
 

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -375,7 +375,13 @@ namespace XingManager
                 // 3) Persist to DWG/tables only if requested
                 if (applyToTables)
                 {
-                    try { _repository.ApplyChanges(_records.ToList(), _tableSync); }
+                    var snapshot = _records.ToList();
+
+                    try
+                    {
+                        _repository.ApplyChanges(snapshot, _tableSync);
+                        _tableSync.UpdateLatLongSourceTables(_doc, snapshot);
+                    }
                     catch (Exception ex)
                     {
                         MessageBox.Show(ex.Message, "Crossing Manager",


### PR DESCRIPTION
## Summary
- propagate the chosen canonical LAT/LONG values to all table sources for the affected crossing
- keep LAT/LONG table rows in sync with the resolved record values to avoid repeated duplicate prompts
- update LAT/LONG source tables immediately after resolving duplicates so every table reflects the chosen canonical values

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e01f84c2288322bf8b2f92ed6e2804