### PR TITLE
Ensure LAT/LONG selections refresh UI and tables

### DIFF
--- a/XingManager/Services/LatLongDuplicateResolver.cs
+++ b/XingManager/Services/LatLongDuplicateResolver.cs
@@ -57,6 +57,18 @@ namespace XingManager.Services
                 if (!string.IsNullOrWhiteSpace(selected.DwgRef))
                     record.DwgRef = selected.DwgRef;
 
+                if (record.LatLongSources != null && record.LatLongSources.Count > 0)
+                {
+                    foreach (var source in record.LatLongSources)
+                    {
+                        source.Lat = selected.Lat;
+                        source.Long = selected.Long;
+                        source.Zone = selected.Zone;
+                        if (!string.IsNullOrWhiteSpace(selected.DwgRef))
+                            source.DwgRef = selected.DwgRef;
+                    }
+                }
+
                 foreach (var instanceId in record.AllInstances)
                 {
                     if (contexts != null && contexts.TryGetValue(instanceId, out var ctx) && ctx != null)
@@ -485,10 +497,7 @@ namespace XingManager.Services
                 public void SetCanonical(bool isCanonical)
                 {
                     foreach (var member in _members)
-                        member.Canonical = false;
-
-                    if (isCanonical)
-                        Representative.Canonical = true;
+                        member.Canonical = isCanonical;
                 }
             }
         }

--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -180,28 +180,34 @@ namespace XingManager.Services
                         continue;
 
                     var identifiedType = IdentifyTable(table, tr);
-                    if (identifiedType == XingTableType.LatLong)
-                    {
-                        // Already handled by the regular update path.
-                        continue;
-                    }
-
                     try
                     {
                         var rowIndexMap = BuildLatLongRowIndexMap(table.ObjectId, byKey?.Values);
                         UpdateLatLongTable(table, byKey, out var matched, out var updated, rowIndexMap);
-                        _factory.TagTable(tr, table, XingTableType.LatLong.ToString().ToUpperInvariant());
+
+                        var typeLabel = XingTableType.LatLong.ToString().ToUpperInvariant();
+                        _factory.TagTable(tr, table, typeLabel);
+
+                        var suffix = identifiedType == XingTableType.LatLong
+                            ? string.Empty
+                            : " (source-scan)";
+
                         Log(string.Format(
                             CultureInfo.InvariantCulture,
-                            "Table {0}: LATLONG (source-scan) matched={1} updated={2}",
-                            table.ObjectId.Handle, matched, updated));
+                            "Table {0}: {1}{2} matched={3} updated={4}",
+                            table.ObjectId.Handle,
+                            typeLabel,
+                            suffix,
+                            matched,
+                            updated));
                     }
                     catch (Exception ex)
                     {
                         Log(string.Format(
                             CultureInfo.InvariantCulture,
                             "Failed to update LAT/LONG table {0}: {1}",
-                            table.ObjectId.Handle, ex.Message));
+                            table.ObjectId.Handle,
+                            ex.Message));
                     }
                 }
 

--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -370,12 +370,27 @@ namespace XingManager
                 // 2) Resolve duplicates (choose canonicals)
                 var duplicateResolutionOk = _duplicateResolver.ResolveDuplicates(_records, _contexts);
                 var latLongResolutionOk = _latLongDuplicateResolver.ResolveDuplicates(_records, _contexts);
-                if (!duplicateResolutionOk || !latLongResolutionOk) { gridCrossings.Refresh(); _isDirty = false; return; }
+                if (!duplicateResolutionOk || !latLongResolutionOk)
+                {
+                    _records?.ResetBindings();
+                    gridCrossings.Refresh();
+                    _isDirty = false;
+                    return;
+                }
+
+                _records.ResetBindings();
+                gridCrossings.Refresh();
 
                 // 3) Persist to DWG/tables only if requested
                 if (applyToTables)
                 {
-                    try { _repository.ApplyChanges(_records.ToList(), _tableSync); }
+                    var snapshot = _records.ToList();
+
+                    try
+                    {
+                        _repository.ApplyChanges(snapshot, _tableSync);
+                        _tableSync.UpdateLatLongSourceTables(_doc, snapshot);
+                    }
                     catch (Exception ex)
                     {
                         MessageBox.Show(ex.Message, "Crossing Manager",
@@ -384,22 +399,23 @@ namespace XingManager
 
                     // 4) Re-read to reflect the new persisted state
                     var post = _repository.ScanCrossings();
-                _records = new BindingList<CrossingRecord>(post.Records.ToList());
-                _contexts = post.InstanceContexts ?? new Dictionary<ObjectId, DuplicateResolver.InstanceContext>();
-                gridCrossings.DataSource = _records;
-            }
+                    _records = new BindingList<CrossingRecord>(post.Records.ToList());
+                    _contexts = post.InstanceContexts ?? new Dictionary<ObjectId, DuplicateResolver.InstanceContext>();
+                    gridCrossings.DataSource = _records;
+                    _records.ResetBindings();
+                    gridCrossings.Refresh();
+                }
 
-            gridCrossings.Refresh();
-            _isDirty = false;
-            UpdateZoneSelectionFromRecords();
+                _isDirty = false;
+                UpdateZoneSelectionFromRecords();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Crossing Manager",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally { _isScanning = false; }
         }
-        catch (Exception ex)
-        {
-            MessageBox.Show(ex.Message, "Crossing Manager",
-                MessageBoxButtons.OK, MessageBoxIcon.Error);
-        }
-        finally { _isScanning = false; }
-    }
 
         private void ApplyChangesToDrawing()
         {


### PR DESCRIPTION
## Summary
- propagate the canonical selection to every LAT/LONG candidate so the resolver updates the chosen source consistently
- reset the crossings binding list after resolving duplicates and after reloading records so the grid reflects the selected LAT/LONG before updating tables

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e01f84c2288322bf8b2f92ed6e2804