### PR TITLE
Lock tables before updating to prevent eLock errors

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -78,6 +78,7 @@ namespace XingManager.Services
             _ed = doc.Editor;
             var byKey = records.ToDictionary(r => r.CrossingKey, r => r, StringComparer.OrdinalIgnoreCase);
 
+            using (doc.LockDocument())
             using (var tr = db.TransactionManager.StartTransaction())
             {
                 var blockTable = (BlockTable)tr.GetObject(db.BlockTableId, OpenMode.ForRead);


### PR DESCRIPTION
## Summary
- acquire a document lock before iterating AutoCAD tables so updates run while the drawing is locked, preventing eLock violations during Apply to Drawing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e029243e588322855d8487952202e0