### PR TITLE
Handle alternate location headers when parsing tables

### DIFF
--- a/XingManager/Services/TableSync.cs
+++ b/XingManager/Services/TableSync.cs
@@ -28,6 +28,15 @@ namespace XingManager.Services
             LatLong
         }
 
+        private static readonly HashSet<string> MainLocationColumnSynonyms = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "LOCATION",
+            "LOC",
+            "LOCATIONS",
+            "XINGLOCATION",
+            "XINGLOCATIONS"
+        };
+
         private static readonly HashSet<string> MainDwgColumnSynonyms = new HashSet<string>(StringComparer.Ordinal)
         {
             "DWGREF",
@@ -1818,6 +1827,9 @@ namespace XingManager.Services
             }
 
             var normalized = builder.ToString();
+            if (columnIndex == 3 && MainLocationColumnSynonyms.Contains(normalized))
+                return "LOCATION";
+
             if (columnIndex == 4 || columnIndex == 5)
             {
                 if (MainDwgColumnSynonyms.Contains(normalized)) return "DWGREF";


### PR DESCRIPTION
## Summary
- treat plural and prefixed location column headers as the standard LOCATION header during table normalization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54f2b65c48322ae2912f66b52e311