### PR TITLE
Fix fallback start row handling for table updates

### DIFF
--- a/XingManager/XingForm.cs
+++ b/XingManager/XingForm.cs
@@ -600,12 +600,12 @@ namespace XingManager
                         int matched = 0, updated = 0;
 
                         // Data start row (LAT/LONG tables may have a title + header)
-                        int startRow = 1;
+                        int startRow = 0;
                         if (kind == TableSync.XingTableType.LatLong)
                         {
                             try { startRow = TableSync.FindLatLongDataStartRow(table); } // header-aware  :contentReference[oaicite:8]{index=8}
-                            catch { startRow = 1; }
-                            if (startRow <= 0) startRow = 1;
+                            catch { startRow = 0; }
+                            if (startRow < 0) startRow = 0;
                         }
 
                         for (int row = startRow; row < table.Rows.Count; row++)
@@ -1111,12 +1111,12 @@ namespace XingManager
 
                         table.UpgradeOpen();
 
-                        int startRow = 1;
+                        int startRow = 0;
                         if (kind == TableSync.XingTableType.LatLong)
                         {
                             try { startRow = TableSync.FindLatLongDataStartRow(table); }
-                            catch { startRow = 1; }
-                            if (startRow <= 0) startRow = 1;
+                            catch { startRow = 0; }
+                            if (startRow < 0) startRow = 0;
                         }
 
                         for (int row = startRow; row < table.Rows.Count; row++)


### PR DESCRIPTION
## Summary
- default table iteration to row 0 so first records are processed when no header is detected
- ensure lat/long start row detection falls back to 0 instead of skipping the first data row
- apply the same fix when deleting rows from detected tables

## Testing
- not run (AutoCAD-dependent)

------
https://chatgpt.com/codex/tasks/task_e_68e554004d20832294d5246beeeed80d